### PR TITLE
Improvements on the entry.get_input_stream method

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -182,12 +182,7 @@ module Zip
       end
 
       def read_c_dir_entry(io) #:nodoc:all
-        path = if io.respond_to?(:path)
-                 io.path
-               else
-                 io
-               end
-        entry = new(path)
+        entry = new(io)
         entry.read_c_dir_entry(io)
         entry
       rescue Error
@@ -490,7 +485,7 @@ module Zip
 
     # Returns an IO like object for the given ZipEntry.
     # Warning: may behave weird with symlinks.
-    def get_input_stream(archive = nil, &block)
+    def get_input_stream(&block)
       if @ftype == :directory
         yield ::Zip::NullInputStream if block_given?
         ::Zip::NullInputStream
@@ -508,7 +503,7 @@ module Zip
         end
       else
         cd_entry = self
-        zis = ::Zip::InputStream.new(archive || @zipfile, cd_entry, local_header_offset)
+        zis = ::Zip::InputStream.new(@zipfile, cd_entry, local_header_offset)
         zis.instance_variable_set(:@internal, true)
         zis.get_next_entry
         if block_given?

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -490,7 +490,7 @@ module Zip
 
     # Returns an IO like object for the given ZipEntry.
     # Warning: may behave weird with symlinks.
-    def get_input_stream(&block)
+    def get_input_stream(archive = nil, &block)
       if @ftype == :directory
         yield ::Zip::NullInputStream if block_given?
         ::Zip::NullInputStream
@@ -508,7 +508,7 @@ module Zip
         end
       else
         cd_entry = self
-        zis = ::Zip::InputStream.new(@zipfile, cd_entry, local_header_offset)
+        zis = ::Zip::InputStream.new(archive || @zipfile, cd_entry, local_header_offset)
         zis.instance_variable_set(:@internal, true)
         zis.get_next_entry
         if block_given?

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -194,9 +194,9 @@ module Zip
         nil
       end
 
-      def read_local_entry(io)
+      def read_local_entry(io, cd_entry = nil)
         entry = new(io)
-        entry.read_local_entry(io)
+        entry.read_local_entry(io, cd_entry)
         entry
       rescue Error
         nil
@@ -220,7 +220,7 @@ module Zip
         @extra_length = buf.unpack('VCCvvvvVVVvv')
     end
 
-    def read_local_entry(io) #:nodoc:all
+    def read_local_entry(io, cd_entry = nil) #:nodoc:all
       @local_header_offset = io.tell
 
       static_sized_fields_buf = io.read(::Zip::LOCAL_ENTRY_STATIC_HEADER_LENGTH) || ''
@@ -230,6 +230,14 @@ module Zip
       end
 
       unpack_local_entry(static_sized_fields_buf)
+
+      # overwrite size, compressed_size and crc with those of the file headers of the central directory
+      # when local file headers are not found in the beginning of the file
+      if cd_entry && gp_flags & 8 == 8 && size == 0 && crc == 0 && compressed_size == 0
+        @size             = cd_entry.size
+        @crc              = cd_entry.crc
+        @compressed_size  = cd_entry.compressed_size
+      end
 
       unless @header_signature == ::Zip::LOCAL_ENTRY_SIGNATURE
         raise ::Zip::Error, "Zip local header magic not found at location '#{local_header_offset}'"
@@ -499,7 +507,8 @@ module Zip
           raise "unknown @file_type #{@ftype}"
         end
       else
-        zis = ::Zip::InputStream.new(@zipfile, local_header_offset)
+        cd_entry = self
+        zis = ::Zip::InputStream.new(@zipfile, cd_entry, local_header_offset)
         zis.instance_variable_set(:@internal, true)
         zis.get_next_entry
         if block_given?

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -62,8 +62,6 @@ module Zip
     # Returns the zip files comment, if it has one
     attr_accessor :comment
 
-    attr_accessor :archive
-
     # Opens a zip archive. Pass true as the second parameter to create
     # a new archive if it doesn't exist already.
     def initialize(file_name, create = false, buffer = false, options = {})
@@ -74,8 +72,8 @@ module Zip
       if !buffer && ::File.size?(file_name)
         @create = false
         @file_permissions = ::File.stat(file_name).mode
-        @archive = ::File.open(name, 'rb')
-        read_from_stream(@archive)
+        archive = ::File.open(name, 'rb')
+        read_from_stream(archive)
       elsif @create
         @entry_set = EntrySet.new
       elsif ::File.zero?(file_name)

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -62,6 +62,8 @@ module Zip
     # Returns the zip files comment, if it has one
     attr_accessor :comment
 
+    attr_accessor :archive
+
     # Opens a zip archive. Pass true as the second parameter to create
     # a new archive if it doesn't exist already.
     def initialize(file_name, create = false, buffer = false, options = {})
@@ -72,9 +74,8 @@ module Zip
       if !buffer && ::File.size?(file_name)
         @create = false
         @file_permissions = ::File.stat(file_name).mode
-        ::File.open(name, 'rb') do |f|
-          read_from_stream(f)
-        end
+        @archive = ::File.open(name, 'rb')
+        read_from_stream(@archive)
       elsif @create
         @entry_set = EntrySet.new
       elsif ::File.zero?(file_name)

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -46,13 +46,15 @@ module Zip
     # not a local zip entry header.
     #
     # @param context [String||IO||StringIO] file path or IO/StringIO object
+    # @param cd_entry [Entry] entry from the central directory
     # @param offset [Integer] offset in the IO/StringIO
-    def initialize(context, offset = 0, decrypter = nil)
+    def initialize(context, cd_entry, offset = 0, decrypter = nil)
       super()
       @archive_io = get_io(context, offset)
       @decompressor  = ::Zip::NullDecompressor
       @decrypter     = decrypter || ::Zip::NullDecrypter.new
       @current_entry = nil
+      @cd_entry = cd_entry
     end
 
     def close
@@ -123,10 +125,12 @@ module Zip
     end
 
     def open_entry
-      @current_entry = ::Zip::Entry.read_local_entry(@archive_io)
+      @current_entry = ::Zip::Entry.read_local_entry(@archive_io, @cd_entry)
+
       if @current_entry && @current_entry.gp_flags & 1 == 1 && @decrypter.is_a?(NullEncrypter)
         raise Error, 'password required to decode zip file'
       end
+
       if @current_entry && @current_entry.gp_flags & 8 == 8 && @current_entry.crc == 0 \
         && @current_entry.compressed_size == 0 \
         && @current_entry.empty? && !@internal

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -48,7 +48,7 @@ module Zip
     # @param context [String||IO||StringIO] file path or IO/StringIO object
     # @param cd_entry [Entry] entry from the central directory
     # @param offset [Integer] offset in the IO/StringIO
-    def initialize(context, cd_entry, offset = 0, decrypter = nil)
+    def initialize(context, cd_entry = nil, offset = 0, decrypter = nil)
       super()
       @archive_io = get_io(context, offset)
       @decompressor  = ::Zip::NullDecompressor
@@ -95,7 +95,7 @@ module Zip
       # stream is passed to the block and closed when the block
       # returns.
       def open(filename_or_io, offset = 0, decrypter = nil)
-        zio = new(filename_or_io, offset, decrypter)
+        zio = new(filename_or_io, nil, offset, decrypter)
         return zio unless block_given?
         begin
           yield zio

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -39,7 +39,6 @@ class ZipFileTest < MiniTest::Test
     zfRead = ::Zip::File.new(EMPTY_FILENAME)
     assert_equal(comment, zfRead.comment)
     assert_equal(2, zfRead.entries.length)
-    assert_equal(File, zfRead.archive.class)
   end
 
   def test_create_from_scratch_with_old_create_parameter

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -39,6 +39,7 @@ class ZipFileTest < MiniTest::Test
     zfRead = ::Zip::File.new(EMPTY_FILENAME)
     assert_equal(comment, zfRead.comment)
     assert_equal(2, zfRead.entries.length)
+    assert_equal(File, zfRead.archive.class)
   end
 
   def test_create_from_scratch_with_old_create_parameter


### PR DESCRIPTION
#### Fix bug
When the local file header had a flag Bit 3, it was impossible to read the `size`, the `compressed_size` and the `crc` of the data descriptor. We now pass the central directory entry when calling the `get_input_stream` so each entry can now reach its information.

#### Improve performance
Instead of calling à `File.open` on each entry when calling `get_input_stream`, we now pass the archive in reference